### PR TITLE
Improve exceptions handling and reporting

### DIFF
--- a/lib/pulsar.rb
+++ b/lib/pulsar.rb
@@ -8,6 +8,7 @@ module Pulsar
   require 'interactor'
   require 'fileutils'
 
+  require 'pulsar/error_handler'
   require 'pulsar/interactors/cleanup'
   require 'pulsar/interactors/create_run_dirs'
   require 'pulsar/interactors/add_applications'

--- a/lib/pulsar/cli.rb
+++ b/lib/pulsar/cli.rb
@@ -34,6 +34,7 @@ module Pulsar
         puts result.applications
       else
         puts 'Failed to list application and environments.'
+        puts result.errors.inspect
       end
     end
 

--- a/lib/pulsar/cli.rb
+++ b/lib/pulsar/cli.rb
@@ -34,7 +34,7 @@ module Pulsar
         puts result.applications
       else
         puts 'Failed to list application and environments.'
-        puts result.errors.inspect
+        puts result.errors
       end
     end
 

--- a/lib/pulsar/error_handler.rb
+++ b/lib/pulsar/error_handler.rb
@@ -1,0 +1,14 @@
+module Pulsar
+  module ErrorHandler
+    def context_fail!(params = {})
+      context.errors ||= []
+      errors = params.delete :errors
+      context.errors << errors if errors
+      context.fail! params
+    end
+  end
+end
+
+Interactor.class_eval do
+  include Pulsar::ErrorHandler
+end

--- a/lib/pulsar/interactors/add_applications.rb
+++ b/lib/pulsar/interactors/add_applications.rb
@@ -10,7 +10,7 @@ module Pulsar
         context.applications << "#{File.basename(app)}: #{stages_for(app)}"
       end
     rescue
-      context.fail!
+      context_fail! errors: $!.message
     end
 
     private
@@ -20,11 +20,11 @@ module Pulsar
     end
 
     def validate_input!
-      context.fail! if context.config_path.nil?
+      context_fail! errors: "Empty config path" if context.config_path.nil?
     end
 
     def validate_output!
-      context.fail! if context.applications.empty?
+      context_fail! errors: "No application found for repository at #{context.repository}" if context.applications.empty?
     end
 
     def each_application_path

--- a/lib/pulsar/interactors/clone_repository.rb
+++ b/lib/pulsar/interactors/clone_repository.rb
@@ -11,13 +11,13 @@ module Pulsar
       when :folder then copy_local_folder
       end
     rescue
-      context.fail!
+      context_fail!
     end
 
     private
 
     def validate_input!
-      context.fail! if context.config_path.nil? ||
+      context_fail! if context.config_path.nil? ||
                        context.repository.nil? ||
                        context.repository_type.nil?
     end
@@ -30,6 +30,8 @@ module Pulsar
       Rake.sh(
         "#{cmd} #{opts} #{context.repository} #{context.config_path} #{quiet}"
       )
+    rescue
+      context_fail! errors: "No repository found at #{context.repository}"
     end
 
     def clone_github_repository
@@ -44,6 +46,7 @@ module Pulsar
     end
 
     def copy_local_folder
+      context_fail! errors: "No repository found at #{context.repository}" unless File.exist? context.repository
       FileUtils.cp_r("#{context.repository}/.", context.config_path)
     end
   end

--- a/lib/pulsar/interactors/copy_environment_file.rb
+++ b/lib/pulsar/interactors/copy_environment_file.rb
@@ -10,7 +10,7 @@ module Pulsar
       FileUtils.mkdir_p(context.cap_deploy_path)
       FileUtils.cp(env_file, context.environment_file_path)
     rescue
-      context.fail!
+      context_fail! errors: $!.message
     end
 
     private
@@ -21,7 +21,7 @@ module Pulsar
     end
 
     def validate_input!
-      context.fail! if context.config_path.nil? ||
+      context_fail! if context.config_path.nil? ||
                        context.cap_path.nil? ||
                        context.application.nil? ||
                        context.environment.nil?

--- a/lib/pulsar/interactors/copy_initial_repository.rb
+++ b/lib/pulsar/interactors/copy_initial_repository.rb
@@ -10,13 +10,13 @@ module Pulsar
 
       FileUtils.cp_r(File.expand_path(initial_repo), context.directory)
     rescue
-      context.fail!
+      context_fail! errors: $!.message
     end
 
     private
 
     def validate_input!
-      context.fail! if context.directory.nil?
+      context_fail! if context.directory.nil?
     end
   end
 end

--- a/lib/pulsar/interactors/create_capfile.rb
+++ b/lib/pulsar/interactors/create_capfile.rb
@@ -14,7 +14,7 @@ module Pulsar
       Rake.sh("cat #{app_capfile}     >> #{context.capfile_path}") if File.exist?(app_capfile)
       Rake.sh("echo '#{import_tasks}' >> #{context.capfile_path}")
     rescue
-      context.fail!
+      context_fail! errors: $!.message
     end
 
     private
@@ -24,7 +24,7 @@ module Pulsar
     end
 
     def validate_input!
-      context.fail! if context.config_path.nil? ||
+      context_fail! if context.config_path.nil? ||
                        context.cap_path.nil? ||
                        context.application.nil?
     end

--- a/lib/pulsar/interactors/create_deploy_file.rb
+++ b/lib/pulsar/interactors/create_deploy_file.rb
@@ -13,7 +13,7 @@ module Pulsar
       Rake.sh("cat #{default_deploy} >> #{context.deploy_file_path}") if File.exist?(default_deploy)
       Rake.sh("cat #{app_deploy}     >> #{context.deploy_file_path}") if File.exist?(app_deploy)
     rescue
-      context.fail!
+      context_fail! errors: $!.message
     end
 
     private
@@ -24,7 +24,7 @@ module Pulsar
     end
 
     def validate_input!
-      context.fail! if context.config_path.nil? ||
+      context_fail! if context.config_path.nil? ||
                        context.cap_path.nil? ||
                        context.application.nil?
     end

--- a/lib/pulsar/interactors/identify_repository_location.rb
+++ b/lib/pulsar/interactors/identify_repository_location.rb
@@ -11,13 +11,13 @@ module Pulsar
                                       :remote
                                     end
     rescue
-      context.fail!
+      context_fail! errors: $!.message
     end
 
     private
 
     def validate_input!
-      context.fail! if context.repository.nil?
+      context_fail! if context.repository.nil?
     end
   end
 end

--- a/lib/pulsar/interactors/identify_repository_type.rb
+++ b/lib/pulsar/interactors/identify_repository_type.rb
@@ -12,14 +12,14 @@ module Pulsar
         context.repository_type = github_repository? ? :github : :git
       end
     rescue
-      context.fail!
+      context_fail! errors: $!.message
     end
 
     private
 
     def validate_input!
-      context.fail! if context.repository.nil?
-      context.fail! if context.repository_location.nil?
+      context_fail! if context.repository.nil?
+      context_fail! if context.repository_location.nil?
     end
 
     def git_repository?

--- a/lib/pulsar/interactors/run_bundle_install.rb
+++ b/lib/pulsar/interactors/run_bundle_install.rb
@@ -12,16 +12,16 @@ module Pulsar
       bundle_cmd  = "#{cmd_env} bundle check || #{cmd_env} bundle install"
 
       Bundler.with_clean_env do
-        context.fail! unless system("#{bundle_cmd}#{out_redir}")
+        context_fail! unless system("#{bundle_cmd}#{out_redir}")
       end
     rescue
-      context.fail!
+      context_fail! errors: $!.message
     end
 
     private
 
     def validate_input!
-      context.fail! if context.config_path.nil? ||
+      context_fail! if context.config_path.nil? ||
                        context.bundle_path.nil?
     end
   end

--- a/lib/pulsar/interactors/run_capistrano.rb
+++ b/lib/pulsar/interactors/run_capistrano.rb
@@ -12,16 +12,16 @@ module Pulsar
         out_redir   = ENV['DRY_RUN'] ? '> /dev/null 2>&1' : nil
         cap_cmd     = "bundle exec cap #{cap_opts}#{context.environment} deploy"
 
-        context.fail! unless system("#{gemfile_env} #{bundle_env} #{cap_cmd}#{out_redir}")
+        context_fail! errors: "Capistrano command failed!" unless system("#{gemfile_env} #{bundle_env} #{cap_cmd}#{out_redir}")
       end
     rescue
-      context.fail!
+      context_fail! errors: $!.message
     end
 
     private
 
     def validate_input!
-      context.fail! if context.cap_path.nil? ||
+      context_fail! if context.cap_path.nil? ||
                        context.config_path.nil? ||
                        context.bundle_path.nil? ||
                        context.environment.nil?

--- a/spec/features/install_spec.rb
+++ b/spec/features/install_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Install' do
   end
 
   context 'when succeeds' do
-    it { is_expected.to eql "Successfully created intial repo!\n" }
+    it { is_expected.to match "Successfully created intial repo!\n" }
 
     context 'creates a directory' do
       subject { -> { command } }
@@ -55,7 +55,7 @@ RSpec.describe 'Install' do
   context 'when fails' do
     let(:arguments) { '/pulsar-conf' }
 
-    it { is_expected.to eql "Failed to create intial repo.\n" }
+    it { is_expected.to match "Failed to create intial repo.\n" }
 
     context 'does not create a directory' do
       subject { -> { command } }

--- a/spec/features/list_spec.rb
+++ b/spec/features/list_spec.rb
@@ -134,13 +134,13 @@ RSpec.describe 'List' do
     context 'because of wrong directory' do
       let(:repo) { './some-wrong-directory' }
 
-      it { is_expected.to eql "Failed to list application and environments.\n" }
+      it { is_expected.to match "Failed to list application and environments.\n" }
     end
 
     context 'because of empty directory' do
       let(:repo) { RSpec.configuration.pulsar_empty_conf_path }
 
-      it { is_expected.to eql "Failed to list application and environments.\n" }
+      it { is_expected.to match "Failed to list application and environments.\n" }
     end
   end
 end

--- a/spec/features/list_spec.rb
+++ b/spec/features/list_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'List' do
     subject { command }
 
     context 'because of wrong directory' do
-      let(:repo) { './some-wrong-directory' }
+      let(:repo) { './some-non-existent-directory' }
 
       it { is_expected.to match "Failed to list application and environments.\n" }
     end

--- a/spec/units/interactors/clone_repository_spec.rb
+++ b/spec/units/interactors/clone_repository_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Pulsar::CloneRepository do
     context 'success' do
       context 'when repository_type is :folder' do
         let(:type) { :folder }
+        let(:repo) { "#{RSpec.configuration.pulsar_conf_path}" }
 
         before do
           expect(FileUtils).to receive(:cp_r).with("#{repo}/.", run_path).ordered


### PR DESCRIPTION
Bisogna definire le eccezioni che vale la pena gestire separatamente. Proposte:

+ è bene discriminare tra repo inesistenti (così da dare un feedback immediato nel caso si sia sbagliato a digitare il nome del repo), da quelli invalidi.

Non so per quale motivo ma `$!.message` ritorna un output troncato a 81 caratteri quando l'errore contiene un comandi di shell eseguiti via `Rake.sh`